### PR TITLE
Fix korean fonts problem

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -18,7 +18,7 @@ dependencies:
 ## Customize compile commands
 test:
   override:
-    - docker run --rm -w "/doc" -v "$PWD":/doc thomasweise/texlive make
+    - docker run --rm -w "/doc" -v "$PWD":/doc jonghoonseo/tex-with-nanumgothic make
   post:
     - mv *.pdf $CIRCLE_ARTIFACTS/
 

--- a/cv.tex
+++ b/cv.tex
@@ -46,6 +46,7 @@
 \usepackage{hyperref}		% To support hyperlink for newcommand
 \usepackage{mfirstuc}
 
+\setmainfont{Batang}
 
 % Set false if you don't want to highlight section with awesome color
 \setbool{acvSectionColorHighlight}{true}

--- a/cv.tex
+++ b/cv.tex
@@ -46,7 +46,8 @@
 \usepackage{hyperref}		% To support hyperlink for newcommand
 \usepackage{mfirstuc}
 
-\setmainfont{Batang}
+\setmainhangulfont{NanumGothic}
+\setsanshangulfont{NanumGothic}
 
 % Set false if you don't want to highlight section with awesome color
 \setbool{acvSectionColorHighlight}{true}


### PR DESCRIPTION
This pull request is related with #5 

Change Note
- Modify cv.tex to override Korean fonts (591f9bec2f19230fd0166444dcc491bddd01f08b)
- Change circleCI build script to use jonghoonseo/tex-with-nanumgothic docker image (aa5e4e64f78b1cb0887a7e257c15c8ef62be970d)